### PR TITLE
Add configuration/smtp endpoint to update

### DIFF
--- a/rs/gluu/gluu_lib.py
+++ b/rs/gluu/gluu_lib.py
@@ -300,7 +300,8 @@ class OxTrustAPIClient:
         """
         config_endpoints = ["configuration/oxauth/settings",
                             "configuration/oxtrust/settings",
-                            "configuration/settings"
+                            "configuration/settings",
+                            "configuration/smtp"
                             ]
         available_endpoints = {
             'attributes': 'attributes',


### PR DESCRIPTION
According to https://gluu.org/docs/gluu-server/4.3/api-guide/oxtrust-api/#api-reference the smtp configuration has its own endpoint that only supports GET and PUT. The end point needs to be in the allowed endpoints for a PUT request. 